### PR TITLE
Concurrency fix (Илья Засимов / Austry)

### DIFF
--- a/app/src/main/java/ru/yandex/yamblz/concurrency/LoadProducer.java
+++ b/app/src/main/java/ru/yandex/yamblz/concurrency/LoadProducer.java
@@ -3,6 +3,7 @@ package ru.yandex.yamblz.concurrency;
 import android.support.annotation.NonNull;
 
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * Simple load producer thread; non-extensible
@@ -14,21 +15,22 @@ public final class LoadProducer extends Thread {
 
     @NonNull private final Set<String> results;
     @NonNull private final Runnable onResult;
+    @NonNull private final CountDownLatch latch;
 
-    public LoadProducer(@NonNull Set<String> resultSet, @NonNull Runnable onResult) {
+    public LoadProducer(@NonNull Set<String> resultSet, @NonNull Runnable onResult, @NonNull CountDownLatch latch) {
         this.results = resultSet;
         this.onResult = onResult;
+        this.latch = latch;
     }
 
     @Override
     public void run() {
         super.run();
 
-        /* Synchronize via concurrent mechanics */
-
         final String result = new DownloadLatch().doWork();
         results.add(result);
 
         onResult.run();
+        latch.countDown();
     }
 }

--- a/app/src/main/java/ru/yandex/yamblz/concurrency/PostConsumer.java
+++ b/app/src/main/java/ru/yandex/yamblz/concurrency/PostConsumer.java
@@ -2,6 +2,8 @@ package ru.yandex.yamblz.concurrency;
 
 import android.support.annotation.NonNull;
 
+import java.util.concurrent.CountDownLatch;
+
 /**
  * Simple result consumer thread; non-extensible
  *
@@ -10,18 +12,29 @@ import android.support.annotation.NonNull;
 
 public final class PostConsumer extends Thread {
 
-    @NonNull private final Runnable onFinish;
+    @NonNull
+    private final Runnable onFinish;
+    @NonNull
+    private final CountDownLatch latch;
 
-    public PostConsumer(@NonNull Runnable onFinish) {
+    public PostConsumer(@NonNull Runnable onFinish, @NonNull CountDownLatch latch) {
         this.onFinish = onFinish;
+        this.latch = latch;
     }
 
     @Override
     public void run() {
+        waitLatch();
+
         super.run();
-
-        /* Synchronize via concurrent mechanics */
-
         onFinish.run();
+    }
+
+    private void waitLatch() {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/app/src/main/java/ru/yandex/yamblz/ui/fragments/ContentFragment.java
+++ b/app/src/main/java/ru/yandex/yamblz/ui/fragments/ContentFragment.java
@@ -8,8 +8,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import java.util.LinkedHashSet;
+import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 
 import butterknife.BindView;
@@ -26,7 +27,7 @@ public class ContentFragment extends BaseFragment {
 
     @BindView(R.id.hello) TextView helloView;
 
-    @NonNull private final Set<String> dataResults = new LinkedHashSet<>();
+    @NonNull private final Set<String> dataResults = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     @NonNull
     @Override

--- a/app/src/main/java/ru/yandex/yamblz/ui/fragments/ContentFragment.java
+++ b/app/src/main/java/ru/yandex/yamblz/ui/fragments/ContentFragment.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 
 import butterknife.BindView;
 import ru.yandex.yamblz.R;
@@ -21,6 +22,7 @@ public class ContentFragment extends BaseFragment {
 
     private static final String CONSUME_EXCEPTION = "Some producers not finished yet!";
     private static final int PRODUCERS_COUNT = 5;
+
 
     @BindView(R.id.hello) TextView helloView;
 
@@ -35,23 +37,30 @@ public class ContentFragment extends BaseFragment {
     @Override
     public void onResume() {
         super.onResume();
-        new PostConsumer(this::postFinish).start();
+        CountDownLatch latch = new CountDownLatch(PRODUCERS_COUNT);
+
+        new PostConsumer(this::postFinish, latch).start();
         for (int i = 0; i < PRODUCERS_COUNT; i++) {
-            new LoadProducer(dataResults, this::postResult);
+            new LoadProducer(dataResults, this::postResult, latch).start();
         }
     }
 
     final void postResult() {
-        assert helloView != null;
-        helloView.setText(String.valueOf(dataResults.size()));
+        runOnUiThreadIfFragmentAlive(() ->{
+            assert helloView != null;
+            helloView.setText(String.valueOf(dataResults.size()));
+        });
     }
 
     final void postFinish() {
+
         if (dataResults.size() < PRODUCERS_COUNT) {
             throw new RuntimeException(CONSUME_EXCEPTION);
         }
 
-        assert helloView != null;
-        helloView.setText(R.string.task_win);
+        runOnUiThreadIfFragmentAlive(() ->{
+            assert helloView != null;
+            helloView.setText(R.string.task_win);
+        });
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
         compileSdk                   : 23,
         buildTools                   : '23.0.3',
 
-        androidGradlePlugin          : '2.2.0-alpha4',
+        androidGradlePlugin          : '2.1.2',
         aptGradlePlugin              : '1.8',
         retrolambdaGradlePlugin      : '3.2.5',
         lombokGradlePlugin           : '0.2.3.a2',


### PR DESCRIPTION
Привет!
Во время выполнения возникло несколько вопросов:
1) Не нужно выносить всю эту асинхронность в какой-нибудь RetainFragment или сделать этот фрагмент retain? И если нет, то что делать с уже запушенными потоками после пересоздания(при повороте)? Вот запустилось 6 потоков, мы повернули телефон и запустили ещё 6, а старые продолжают работать и должны попытаться вызвать свой коллбек в итоге. Стоит сохранять ссылки на старые потоки и при пересоздании вызывать на них всех interrupt() например? Ну и соответственно не вызывать колбек если проток прерван. Или что с этим делать?
2) Я запустил тулзы для проверки и получил от PMD такую проблему - Avoid printStackTrace(); use a logger call instead. Но это происходит в классе PostConsumer который "pure java" и он может ничего не знать о том, что как-то связан с андроидом. По этому я не стал менять printStackTrace на Log.e. Правильно ли это или нужно слушать такие тулзы безоговорочно? 
3) Опять про тулзы для проверки. Запускал через ./gradlew check и билд падает на checkstyle. Пошел поправил. Опять запускаю - падает на PMD. Поправил - падает на lint. Нельзя как-то запустить этот процесс чтобы увидеть результат всех проверок сразу? 
